### PR TITLE
Removing restriction on the flyway command that can be run

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A GitHub Action that will run (Flyway)[https://flywaydb.org/] against a specifie
 | `db-server-port`          | false       | 1433    | The port the database server listens on.                                                                                                            |
 | `db-name`                 | true        | N/A     | The name of the database to run flyway against.                                                                                                     |
 | `migration-files-path`    | true        | N/A     | The path to the base directory containing the migration files to have flyway process.                                                               |
-| `flyway-command`          | true        | N/A     | The flyway command to run. Only migrate and validate are supported at this time.                                                                    |
+| `flyway-command`          | true        | N/A     | The flyway command to run; e.g `migrate`, `validate`, etc.                                                                                          |
 | `migration-history-table` | true        | N/A     | The table where the migration history lives. This is most likely dbo.MigrationHistory or Flyway.MigrationHistory.                                   |
 | `baseline-version`        | true        | 0       | The baseline version to send to the flyway command.                                                                                                 |
 | `managed-schemas`         | true        | N/A     | A comma separated list of schemas that are to be managed by Flyway.MigrationHistory.                                                                |
@@ -36,7 +36,7 @@ jobs:
           version: 5.1.4
 
       - name: Run Flyway Migrations
-        uses: im-open/run-flyway-command@v1.1.0
+        uses: im-open/run-flyway-command@v1.2.0
         with:
           db-server-name: 'localhost'
           db-server-port: '1433'

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: The path to the base directory containing the migration files to process with /src/run-flyway.ps1
     required: true
   flyway-command:
-    description: The flyway command to run. Must be either migrate or validate.
+    description: The flyway command to run; e.g migrate, validate, etc.
     required: true
   migration-history-table:
     description: The table where the migration history lives. This is most likely dbo.MigrationHistory or Flyway.MigrationHistory.

--- a/src/run-flyway.ps1
+++ b/src/run-flyway.ps1
@@ -3,7 +3,6 @@ param (
     [string]$dbServerPort,
     [string]$dbName,
     [string]$pathToMigrationFiles,
-    [ValidateSet("migrate", "validate")]
     [string]$flywayCommand,
     [string]$extraParameters,
     [string]$migrationHistoryTable,


### PR DESCRIPTION
The thought behind the restriction was to prevent usage of the action on commands that haven't been tested. In the process of opening up the action to the `repair` command and testing it, I found that the only things that needed to change were the restriction and its documentation.

So my thinking has now changed. I'm open to discussion on the point though 😃 