### PR TITLE
Adding the trust server certificate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run Flyway Migrations
         # You may also reference the major or major.minor version
-        uses: im-open/run-flyway-command@v1.4.1
+        uses: im-open/run-flyway-command@v1.5.0
         with:
           db-server-name: 'localhost'
           db-server-port: '1433'
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run Flyway Migrations
         # You may also reference the major or major.minor version
-        uses: im-open/run-flyway-command@v1.4.1
+        uses: im-open/run-flyway-command@v1.5.0
         with:
           db-server-name: 'localhost'
           db-server-port: '1433'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A GitHub Action that will run [Flyway](https://flywaydb.org/) against a specifie
 | `db-server-name`              | true        | N/A     | The database server name.                                                                                                                                                                                                                  |
 | `db-server-port`              | false       | 1433    | The port the database server listens on.                                                                                                                                                                                                   |
 | `db-name`                     | true        | N/A     | The name of the database to run flyway against.                                                                                                                                                                                            |
+| `trust-server-certificate`    | false       | false   | A boolean that controls whether or not to validate the SQL Server TLS certificate.                                                                                                                                                         |
 | `migration-files-path`        | true        | N/A     | The path to the base directory containing the migration files to have flyway process.                                                                                                                                                      |
 | `flyway-command`              | true        | N/A     | The flyway command to run; e.g `migrate`, `validate`, etc.                                                                                                                                                                                 |
 | `migration-history-table`     | true        | N/A     | The table where the migration history lives. This is most likely dbo.MigrationHistory or Flyway.MigrationHistory.                                                                                                                          |
@@ -57,6 +58,7 @@ jobs:
           db-server-name: 'localhost'
           db-server-port: '1433'
           db-name: 'LocalDb'
+          trust-server-certificate: 'true'
           migration-files-path: './src/Database/Migrations'
           flyway-command: 'migrate'
           migration-history-table: 'dbo.MigrationHistory'
@@ -91,6 +93,7 @@ jobs:
           db-server-name: 'localhost'
           db-server-port: '1433'
           db-name: 'LocalDb'
+          trust-server-certificate: 'true'
           migration-files-path: './src/Database/Migrations'
           flyway-command: 'migrate'
           migration-history-table: 'dbo.MigrationHistory'
@@ -121,12 +124,12 @@ There may be some instances where the bot does not have permission to push chang
 The `auto-update-readme` and PR merge workflows will use the strategies below to determine what the next version will be.  If the `auto-update-readme` workflow was not able to automatically update the README.md action-examples with the next version, the README.md should be updated manually as part of the PR using that calculated version.
 
 This action uses [git-version-lite] to examine commit messages to determine whether to perform a major, minor or patch increment on merge. The following table provides the fragment that should be included in a commit message to active different increment strategies.
-| Increment Type | Commit Message Fragment |
+| Increment Type | Commit Message Fragment                     |
 | -------------- | ------------------------------------------- |
-| major | +semver:breaking |
-| major | +semver:major |
-| minor | +semver:feature |
-| minor | +semver:minor |
+| major          | +semver:breaking                            |
+| major          | +semver:major                               |
+| minor          | +semver:feature                             |
+| minor          | +semver:minor                               |
 | patch          | *default increment type, no comment needed* |
 
 ## Code of Conduct

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   db-name:
     description: The name of the database to run flyway against.
     required: true
+  trust-server-certificate:
+    description: A boolean that controls whether or not to validate the SQL Server TLS certificate.
+    required: false
+    default: 'false'
   migration-files-path:
     description: The path to the base directory containing the migration files to process with /src/run-flyway.ps1
     required: true
@@ -67,6 +71,7 @@ runs:
         -dbServer "${{ inputs.db-server-name }}" `
         -dbServerPort "${{ inputs.db-server-port }}" `
         -dbName "${{ inputs.db-name }}" `
+        -trustServerCertificate:$${{ inputs.trust-server-certificate }} `
         -pathToMigrationFiles "${{ inputs.migration-files-path }}" `
         -flywayCommand "${{ inputs.flyway-command }}" `
         -migrationHistoryTable "${{ inputs.migration-history-table }}" `

--- a/src/run-flyway.ps1
+++ b/src/run-flyway.ps1
@@ -2,6 +2,7 @@ param (
     [string]$dbServer,
     [string]$dbServerPort,
     [string]$dbName,
+    [switch]$trustServerCertificate,
     [string]$pathToMigrationFiles,
     [string]$flywayCommand,
     [string]$extraParameters,
@@ -23,7 +24,7 @@ Write-Information -InformationAction Continue -MessageData "Running $flywayComma
 $flywayLocations = "filesystem:`"$(Resolve-Path $pathToMigrationFiles)`""
 
 try {
-    $jdbcUrl = "jdbc:sqlserver://${dbServer}:$dbServerPort;databaseName=$dbName;"
+    $jdbcUrl = "jdbc:sqlserver://${dbServer}:$dbServerPort;databaseName=$dbName;trustServerCertificate=$trustServerCertificate;"
 
     if ($useIntegratedSecurity) {
         $jdbcUrl += "integratedSecurity=true;"


### PR DESCRIPTION
# Summary of PR changes

Adding a flag so we can can tell the flyway command to trust/not trust the server certificate.

## PR Requirements
- [X] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [X] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
