### PR TITLE
EN-23497 - Adding use azure credential.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: A switch to indicate that an Azure Active Directory Service Principal will be used to authenticate with the SQL Server.
     required: false
     default: 'false'
+  use-azure-default-credential: # Requires flyway version 10.17.0 or later
+    description: A switch to indicate that an Azure Active Directory Credential will be used to authenticate with the SQL Server. This credential includes any credential in the Azure Identity Provider
+    required: false
+    default: 'false'
   username:
     description: The username of the user making the changes, which is put into the MigrationHistory table, and also to login with if not using integrated security. This should be the Service Principal ID if use-azure-service-principal is set to true.
     required: false
@@ -81,6 +85,7 @@ runs:
         -validateMigrations:$${{ inputs.validate-migrations }} `
         -useIntegratedSecurity:$${{ inputs.use-integrated-security }} `
         -useActiveDirectoryServicePrincipal:$${{ inputs.use-azure-service-principal }} `
+        -useActiveDirectoryCredential:$${{ inputs.use-azure-default-credential }} `
         -username "${{ inputs.username }}" `
         -password $securePassword `
         -extraParameters "${{ inputs.extra-parameters }}"

--- a/src/run-flyway.ps1
+++ b/src/run-flyway.ps1
@@ -12,6 +12,7 @@ param (
     [switch]$enableOutOfOrder = $false,
     [switch]$useIntegratedSecurity = $false,
     [switch]$useActiveDirectoryServicePrincipal = $false,
+    [switch]$useActiveDirectoryCredential = $false, # Requires flyway version 10.17.0
     [switch]$validateMigrations = $false,
     [string]$username,
     [SecureString]$password
@@ -31,6 +32,9 @@ try {
     }
     if ($useActiveDirectoryServicePrincipal) {
         $jdbcUrl += "authentication=ActiveDirectoryServicePrincipal;"
+    }
+    if($useActiveDirectoryCredential){
+        $jdbcUrl += "authentication=ActiveDirectoryDefault;"
     }
 
     $outOfOrderValue = $enableOutOfOrder.ToString().ToLower()


### PR DESCRIPTION
# Summary of PR changes

* Adding authentication method `use-azure-default-credential` that supports federated credentials and any other method that `azure.identity` supports.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
